### PR TITLE
moved imagery dropdown to not cover other buttons

### DIFF
--- a/src/components/ImageryDropdownControl.vue
+++ b/src/components/ImageryDropdownControl.vue
@@ -132,7 +132,7 @@ const emitValue = (value) => {
 
 .imagery-dropdown {
   position: absolute !important;
-  top: 11px;
+  top: 52px;
   right: 50px;
   z-index: 2;
 }
@@ -152,14 +152,9 @@ const emitValue = (value) => {
   margin-left: 0px !important;
 }
 
-@media 
+@media
 only screen and (max-width: 760px),
 (min-device-width: 768px) and (max-device-width: 1024px)  {
-  
-  .imagery-dropdown {
-    /* top: 54px; */
-    right: 50px;
-  }
 
   .imagery-dropdown-button {
     padding-top: 1px !important;
@@ -168,7 +163,7 @@ only screen and (max-width: 760px),
 }
 
 .img-src {
-  max-width: 100%; 
+  max-width: 100%;
   border-radius: 5px;
 }
 


### PR DESCRIPTION
dropdown now renders directly to the left of the imagery button and below the half-marathon button